### PR TITLE
Correct Github "Language" tab

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,7 @@
 *.gif           binary
 *.jpg           binary
 *.png           binary
+
+# For Github to correctly show this as a Typescript file,
+# we tell linguist to not tally css files.
+*.css linguist-detectable=false


### PR DESCRIPTION
Correct Github "Language" tab from displaying .css as the repo language. With this fix it should display 'Typescript'. 